### PR TITLE
Let CI only check changed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/istio-testing/website-builder:2019-03-31
+      - image: shidaqiu/servicemesher-trans-circleci:1.0
 
     working_directory: ~/site
 

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.9
+
+MAINTAINER SataQiu <1527062125@qq.com>
+
+RUN apk add --no-cache bash git curl jq
+
+Run apk add --no-cache nodejs-current-npm && \
+    npm install -g markdown-spellcheck
+
+RUN apk add --no-cache ruby ruby-dev ruby-rdoc && \
+    gem install mdl
+

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER SataQiu <1527062125@qq.com>
 
 RUN apk add --no-cache bash git curl jq
 
-Run apk add --no-cache nodejs-current-npm && \
+RUN apk add --no-cache nodejs-current-npm && \
     npm install -g markdown-spellcheck
 
 RUN apk add --no-cache ruby ruby-dev ruby-rdoc && \

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -7,41 +7,59 @@ mdspell --version
 echo -ne "mdl "
 mdl --version
 
-# This performs spell checking and style checking over markdown files in a content
-# directory. 
-check_content() {
-    DIR=$1
-    LANG=$2
+# This performs spell checking and style checking over changed markdown files
+check_pull_request_content() {
 
-    for month in $(ls 2019)
-    do  
-        if [[ ${month} -ge "05" ]]; then
-           mdspell ${LANG} --ignore-acronyms --ignore-numbers --no-suggestions --report "2019/${month}/*/*.md"
-        fi
-    done
-    
-    if [[ "$?" != "0" ]]
-    then
-        FAILED=1
-    fi
+	# only check pull request, skip others
+	if [[ -z $CIRCLE_PULL_REQUEST ]]; then
+		echo "Skip, only check pull request."
+		exit 0
+	fi
 
-    for month in $(ls 2019)
-    do  
-        if [[ ${month} -ge "05" ]]; then
-            mdl --ignore-front-matter --style mdl_style.rb "2019/${month}"
-        fi
-    done
-   
-    if [[ "$?" != "0" ]]
-    then
-        FAILED=1
-    fi
+	# parse target/local branch
+	CIRCLE_PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
+	echo "PR number: $CIRCLE_PR_NUMBER"
+	URL="https://api.github.com/repos/servicemesher/trans/pulls/$CIRCLE_PR_NUMBER"
+	TARGET_BRANCH=$(curl -s -X GET -G $URL | jq '.base.ref' | tr -d '"')
+	LOCAL_BRANCH=$(curl -s -X GET -G $URL | jq '.head.ref' | tr -d '"')
+
+	# get changed files of this PR
+	git checkout -q -b $LOCAL_BRANCH
+	git checkout -q $TARGET_BRANCH
+	git reset --hard -q origin/$TARGET_BRANCH
+	git checkout -q $LOCAL_BRANCH
+
+	echo "Getting list of changed markdown files ..."
+	TOTAL_CHANGED_FILES=( $(git diff --name-only $TARGET_BRANCH..$LOCAL_BRANCH) )
+	echo "Total changed files: ${#TOTAL_CHANGED_FILES[@]}"
+	CHANGED_MARKDOWN_FILES=( $(git diff --name-only $TARGET_BRANCH..$LOCAL_BRANCH -- '*.md') )
+	echo ${CHANGED_MARKDOWN_FILES[@]}
+
+	if [[ "${#CHANGED_MARKDOWN_FILES[@]}" != "0" ]]; then
+		echo "Check spell ..."
+		mdspell --en-us --ignore-acronyms --ignore-numbers --no-suggestions --report ${CHANGED_MARKDOWN_FILES[@]}
+		if [[ "$?" != "0" ]]; then
+			echo "Spell check failed."
+			echo "Feel free to add the word(s) into our glossary file '.spelling'."
+			# set spell check as a weak check for now
+			# FAILED=1
+		fi
+
+		echo "Check style ..."
+		mdl --ignore-front-matter --style mdl_style.rb ${CHANGED_MARKDOWN_FILES[@]}
+		if [[ "$?" != "0" ]]; then
+			FAILED=1
+		fi
+	else
+		echo "No changed markdown files to check."
+	fi
 }
 
-check_content . --en-us
+check_pull_request_content
 
-if [[ ${FAILED} -eq 1 ]]
-then
-    echo "LINTING FAILED"
-    exit 1
+if [[ $FAILED -eq 1 ]]; then
+	echo "LINTING FAILED"
+	exit 1
+else
+	echo "LINTING SUCCEEDED"
 fi


### PR DESCRIPTION
升级 circleci ，仅检查变更的 markdown 文件

暂时将 spell check 设置为弱检查（只检查，不阻止合并），因为很多单词不在术语表中。
最棘手的是，每篇文章都有原作者信息，人名往往不是标准单词，不能每篇文章都修改 `.spelling` 文件。

/cc @rootsongjc @haiker2011 